### PR TITLE
feat: add attachment dialog with Photos & Videos option to chat panel

### DIFF
--- a/resources/views/messages/partials/chat/chat-panel.blade.php
+++ b/resources/views/messages/partials/chat/chat-panel.blade.php
@@ -128,26 +128,60 @@
                 </button>
             </div>
 
+            <!-- Media Preview -->
+            <div id="mediaPreview" class="d-none px-3 py-2 border-top bg-light d-flex align-items-center gap-2">
+                <img id="mediaPreviewImg" src="" alt="preview" style="max-height:80px; max-width:80px; object-fit:cover; border-radius:8px;" class="d-none">
+                <video id="mediaPreviewVideo" src="" style="max-height:80px; max-width:80px; border-radius:8px;" controls class="d-none"></video>
+                <div class="flex-grow-1">
+                    <div id="mediaPreviewName" class="small text-muted"></div>
+                </div>
+                <button type="button" id="removeMedia" class="btn btn-sm btn-outline-danger rounded-pill">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+
             {{-- Input --}}
-            <form id="sendMessageForm" class="d-flex align-items-center gap-2 p-2 border border-top">
+            <form id="sendMessageForm" class="d-flex align-items-center gap-2 p-2 border border-top" enctype="multipart/form-data">
                 @csrf
                 <input type="hidden" name="profile_id" value="{{ $profile?->id }}">
                 <input type="hidden" name="to" id="messageTo" value="{{ $selectedContact }}">
 
                 <!-- Plus -->
-                <button type="button"
-                        class="btn btn-sm rounded-pill bg-secondary-subtle text-primary flex-shrink-0 p-2">
-                    <i class="fas fa-plus"></i>
-                </button>
+                <div class="position-relative flex-shrink-0">
+                    <input type="file"
+                        id="mediaFileInput"
+                        name="media"
+                        accept="image/png,image/jpeg,video/mp4,video/3gpp,video/quicktime"
+                        class="d-none">
+
+                    <button type="button"
+                            id="attachmentToggle"
+                            class="btn btn-sm rounded-pill bg-secondary-subtle text-primary p-2">
+                        <i class="fas fa-plus"></i>
+                    </button>
+
+                    <div id="attachmentDialog"
+                        class="position-absolute bottom-100 start-0 mb-2 bg-white rounded-3 shadow border py-2 d-none"
+                        style="min-width:180px; z-index:1050;">
+                        <button type="button"
+                                id="attachPhotosVideos"
+                                class="btn btn-sm w-100 text-start px-3 py-2 d-flex align-items-center gap-2 rounded-0 border-0 bg-transparent">
+                            <span class="rounded-circle d-flex align-items-center justify-content-center"
+                                style="width:32px;height:32px;background:#e0f0ff;">
+                                <i class="fas fa-image text-primary" style="font-size:14px;"></i>
+                            </span>
+                            <span class="fw-medium">Photos &amp; Videos</span>
+                        </button>
+                    </div>
+                </div>
 
                 <!-- Input -->
                 <div class="flex-grow-1 position-relative">
                     <input type="text"
                         name="message"
                         class="form-control rounded-pill pe-5 bg-secondary-subtle py-2 px-3 border border-primary"
-                        placeholder="Reply with message..."
-                        required>
-
+                        placeholder="Reply with message...">
+            
                     <!-- Icons inside input -->
                     <div class="position-absolute top-50 end-0 translate-middle-y pe-3 d-flex gap-2 z-3">
                         <button type="button" class="btn btn-sm p-1 border-0 bg-transparent">

--- a/resources/views/messages/partials/chat/chat-panel.blade.php
+++ b/resources/views/messages/partials/chat/chat-panel.blade.php
@@ -151,7 +151,7 @@
                     <input type="file"
                         id="mediaFileInput"
                         name="media"
-                        accept="image/png,image/jpeg,video/mp4,video/3gpp,video/quicktime"
+                        accept="image/png,image/jpeg,video/mp4,video/3gpp"
                         class="d-none">
 
                     <button type="button"

--- a/resources/views/messages/partials/chat/scripts/messaging-actions.blade.php
+++ b/resources/views/messages/partials/chat/scripts/messaging-actions.blade.php
@@ -2,15 +2,25 @@
     $('#sendMessageForm').on('submit', function(e) {
         e.preventDefault();
 
-        const form = $(this);
+        const formData = new FormData(this);
 
-        $.post("{{ route('messages.send') }}", form.serialize())
-            .done(function () {
+        $.ajax({
+            url: "{{ route('messages.send') }}",
+            method: 'POST',
+            data: formData,
+            processData: false,
+            contentType: false,
+            success: function() {
+                document.getElementById('mediaFileInput').value = '';
+                document.getElementById('mediaPreview')?.classList.add('d-none');
+                document.getElementById('mediaPreviewImg').src = '';
+                document.getElementById('mediaPreviewVideo').src = '';
                 location.reload();
-            })
-            .fail(function () {
+            },
+            error: function() {
                 alert('Failed to send message');
-            });
+            }
+        });
     });
 
     function bindReturnToBotButton(button) {

--- a/resources/views/messages/partials/chat/scripts/ui-extras.blade.php
+++ b/resources/views/messages/partials/chat/scripts/ui-extras.blade.php
@@ -314,4 +314,63 @@
     } else {
         bindStarRatings(document);
     }
+    // Attachment dialog
+    (function () {
+        const toggle    = document.getElementById('attachmentToggle');
+        const dialog    = document.getElementById('attachmentDialog');
+        const pickBtn   = document.getElementById('attachPhotosVideos');
+        const fileInput = document.getElementById('mediaFileInput');
+
+        if (!toggle || !dialog) return;
+
+        toggle.addEventListener('click', function (e) {
+            e.stopPropagation();
+            dialog.classList.toggle('d-none');
+        });
+
+        document.addEventListener('click', function (e) {
+            if (!dialog.contains(e.target) && !toggle.contains(e.target)) {
+                dialog.classList.add('d-none');
+            }
+        });
+
+        pickBtn.addEventListener('click', function () {
+            dialog.classList.add('d-none');
+            fileInput.click();
+        });
+
+        fileInput.addEventListener('change', function () {
+            const file = fileInput.files[0];
+            if (!file) return;
+
+            const preview = document.getElementById('mediaPreview');
+            const previewImg = document.getElementById('mediaPreviewImg');
+            const previewVideo = document.getElementById('mediaPreviewVideo');
+            const previewName = document.getElementById('mediaPreviewName');
+
+            preview.classList.remove('d-none');
+            previewName.textContent = file.name;
+
+            const reader = new FileReader();
+            reader.onload = function(e) {
+                if (file.type.startsWith('image/')) {
+                    previewImg.src = e.target.result;
+                    previewImg.classList.remove('d-none');
+                    previewVideo.classList.add('d-none');
+                } else {
+                    previewVideo.src = e.target.result;
+                    previewVideo.classList.remove('d-none');
+                    previewImg.classList.add('d-none');
+                }
+            };
+            reader.readAsDataURL(file);
+        });
+
+        document.getElementById('removeMedia')?.addEventListener('click', function() {
+            fileInput.value = '';
+            document.getElementById('mediaPreview').classList.add('d-none');
+            document.getElementById('mediaPreviewImg').src = '';
+            document.getElementById('mediaPreviewVideo').src = '';
+        });
+    })();
 </script>

--- a/src/Http/Controllers/MessagingController.php
+++ b/src/Http/Controllers/MessagingController.php
@@ -707,37 +707,53 @@ class MessagingController extends Controller
     }
     private function uploadLocalMediaToWhatsApp(Channel $profile, string $path, string $mimeType): ?string
     {
-        $absolutePath = storage_path('app/public/' . $path);
+        try {
+            $absolutePath = storage_path('app/public/' . $path);
 
-        if (!file_exists($absolutePath)) {
-            return null;
-        }
+            if (!file_exists($absolutePath)) {
+                Log::error('Media file not found for WhatsApp upload', [
+                    'path' => $absolutePath,
+                ]);
+                return null;
+            }
 
-        $response = Http::withToken($profile->getMeta('system_user_token'))
-            ->attach(
-                'file',
-                fopen($absolutePath, 'r'),
-                basename($absolutePath)
-            )
-            ->post(
-                "https://graph.facebook.com/v18.0/" .
-                $profile->getMeta('whatsapp_phone_number_id') .
-                "/media",
-                [
-                    'messaging_product' => 'whatsapp',
-                    'type' => $mimeType,
-                ]
-            );
+            $fileHandle = fopen($absolutePath, 'r');
 
-        if (!$response->successful()) {
-            Log::error('WhatsApp media upload failed', [
-                'status' => $response->status(),
-                'response' => $response->json(),
+            $response = Http::withToken($profile->getMeta('system_user_token'))
+                ->attach(
+                    'file',
+                    $fileHandle,
+                    basename($absolutePath)
+                )
+                ->post(
+                    "https://graph.facebook.com/v18.0/" .
+                    $profile->getMeta('whatsapp_phone_number_id') .
+                    "/media",
+                    [
+                        'messaging_product' => 'whatsapp',
+                        'type' => $mimeType,
+                    ]
+                );
+
+            fclose($fileHandle);
+
+            if (!$response->successful()) {
+                Log::error('WhatsApp media upload failed', [
+                    'status' => $response->status(),
+                    'response' => $response->json(),
+                ]);
+                return null;
+            }
+
+            return $response->json('id');
+
+        } catch (\Throwable $e) {
+            Log::error('WhatsApp media upload exception', [
+                'path' => $path,
+                'mime_type' => $mimeType,
+                'error' => $e->getMessage(),
             ]);
-
             return null;
         }
-
-        return $response->json('id');
     }
 }

--- a/src/Http/Controllers/MessagingController.php
+++ b/src/Http/Controllers/MessagingController.php
@@ -553,7 +553,7 @@ class MessagingController extends Controller
             'profile_id' => 'required|exists:channels,id',
             'to'         => 'required|string',
             'message'    => 'nullable|string',
-            'media'      => 'nullable|file|mimes:jpeg,png,mp4,3gp,mov|max:16000',
+            'media'      => 'nullable|file|mimes:jpeg,png,mp4,3gp,mov|max:102400',
         ]);
 
         $user = auth()->user();
@@ -611,6 +611,15 @@ class MessagingController extends Controller
             } elseif (in_array($mime, ['video/mp4', 'video/3gpp', 'video/quicktime'])) {
                 $mediaType = 'video';
             }
+            if (!$mediaType) {
+                return response()->json(['error' => 'Unsupported media type'], 422);
+            }
+
+            $whatsappMediaId = $this->uploadLocalMediaToWhatsApp($profile, $path, $mime);
+
+            if (!$whatsappMediaId) {
+                return response()->json(['error' => 'WhatsApp media upload failed'], 500);
+            }
         }
 
         try {
@@ -623,7 +632,7 @@ class MessagingController extends Controller
                     'to'                => $request->to,
                     'type'              => $mediaType,
                     $mediaType          => [
-                        'link'    => $mediaUrl,
+                        'id'      => $whatsappMediaId,
                         'caption' => $request->message ?? '',
                     ],
                 ];
@@ -661,7 +670,11 @@ class MessagingController extends Controller
             'from'         => ($profile->getMeta('country_code') ?? '') . $profile->getMeta('whatsapp_number'),
             'to'           => $request->to,
             'message_type' => $hasMedia ? $mediaType : 'text',
-            'content'      => $hasMedia ? $mediaUrl : $request->message,
+            'content'      => $hasMedia ? json_encode([
+                'caption'           => $request->message ?? '',
+                'media_url'         => $mediaUrl,
+                'whatsapp_media_id' => $whatsappMediaId,
+            ]) : $request->message,
             'timestamp'    => now(),
             'status'       => Constants::SENT,
             'raw_payload'  => $response->json(),
@@ -669,9 +682,10 @@ class MessagingController extends Controller
         ]);
 
         if ($hasMedia) {
+            $message->setMeta('whatsapp_media_id', $whatsappMediaId);
             $message->setMeta('media_url', $mediaUrl);
             $message->setMeta('media_path', $path);
-            $message->setMeta('mime_type', $file->getMimeType());
+            $message->setMeta('media_mime_type', $mime);
             $message->setMeta('media_size', (string) $file->getSize());
         }
 
@@ -690,5 +704,40 @@ class MessagingController extends Controller
                 'message' => 'Failed to send message'
             ], 500);
         }
+    }
+    private function uploadLocalMediaToWhatsApp(Channel $profile, string $path, string $mimeType): ?string
+    {
+        $absolutePath = storage_path('app/public/' . $path);
+
+        if (!file_exists($absolutePath)) {
+            return null;
+        }
+
+        $response = Http::withToken($profile->getMeta('system_user_token'))
+            ->attach(
+                'file',
+                fopen($absolutePath, 'r'),
+                basename($absolutePath)
+            )
+            ->post(
+                "https://graph.facebook.com/v18.0/" .
+                $profile->getMeta('whatsapp_phone_number_id') .
+                "/media",
+                [
+                    'messaging_product' => 'whatsapp',
+                    'type' => $mimeType,
+                ]
+            );
+
+        if (!$response->successful()) {
+            Log::error('WhatsApp media upload failed', [
+                'status' => $response->status(),
+                'response' => $response->json(),
+            ]);
+
+            return null;
+        }
+
+        return $response->json('id');
     }
 }

--- a/src/Http/Controllers/MessagingController.php
+++ b/src/Http/Controllers/MessagingController.php
@@ -551,8 +551,9 @@ class MessagingController extends Controller
     {
         $request->validate([
             'profile_id' => 'required|exists:channels,id',
-            'to' => 'required|string',
-            'message' => 'required|string'
+            'to'         => 'required|string',
+            'message'    => 'nullable|string',
+            'media'      => 'nullable|file|mimes:jpeg,png,mp4,3gp,mov|max:16000',
         ]);
 
         $user = auth()->user();
@@ -594,21 +595,52 @@ class MessagingController extends Controller
         if (!$token || !$phoneNumberId) {
             return response()->json(['error' => 'WhatsApp credentials missing'], 422);
         }
+        $hasMedia = $request->hasFile('media');
+        $mediaType = null;
+        $mediaUrl = null;
+
+        if ($hasMedia) {
+            $file = $request->file('media');
+            $mime = $file->getMimeType();
+
+            $path = $file->store('media/uploads', 'public');
+            $mediaUrl = asset('storage/' . $path);
+
+            if (in_array($mime, ['image/jpeg', 'image/png'])) {
+                $mediaType = 'image';
+            } elseif (in_array($mime, ['video/mp4', 'video/3gpp', 'video/quicktime'])) {
+                $mediaType = 'video';
+            }
+        }
 
         try {
             /**
              * 1️⃣ Send to WhatsApp
              */
+            if ($hasMedia && $mediaType) {
+                $payload = [
+                    'messaging_product' => 'whatsapp',
+                    'to'                => $request->to,
+                    'type'              => $mediaType,
+                    $mediaType          => [
+                        'link'    => $mediaUrl,
+                        'caption' => $request->message ?? '',
+                    ],
+                ];
+            } else {
+                $payload = [
+                    'messaging_product' => 'whatsapp',
+                    'to'                => $request->to,
+                    'type'              => 'text',
+                    'text'              => [
+                        'body' => $request->message,
+                    ],
+                ];
+            }
+
             $response = Http::withToken($token)->post(
                 "https://graph.facebook.com/v18.0/{$phoneNumberId}/messages",
-                [
-                    'messaging_product' => 'whatsapp',
-                    'to' => $request->to,
-                    'type' => 'text',
-                    'text' => [
-                        'body' => $request->message
-                    ]
-                ]
+                $payload
             );
 
             if (!$response->successful()) {
@@ -624,17 +656,24 @@ class MessagingController extends Controller
              * 2️⃣ Save message locally
              */
             $message = Message::create([
-                'channel_id' => $profile->id,
-                'message_id'   => $waMessageId, 
-                'from' => ($profile->getMeta('country_code') ?? '') . $profile->getMeta('whatsapp_number'),
-                'to' => $request->to,
-                'message_type' => 'text',
-                'content' => $request->message,
-                'timestamp' => now(),
-                'status' => Constants::SENT,
-                'raw_payload' => $response->json(),
-                'created_by' => $user->id,
-            ]);
+            'channel_id'   => $profile->id,
+            'message_id'   => $waMessageId,
+            'from'         => ($profile->getMeta('country_code') ?? '') . $profile->getMeta('whatsapp_number'),
+            'to'           => $request->to,
+            'message_type' => $hasMedia ? $mediaType : 'text',
+            'content'      => $hasMedia ? $mediaUrl : $request->message,
+            'timestamp'    => now(),
+            'status'       => Constants::SENT,
+            'raw_payload'  => $response->json(),
+            'created_by'   => $user->id,
+        ]);
+
+        if ($hasMedia) {
+            $message->setMeta('media_url', $mediaUrl);
+            $message->setMeta('media_path', $path);
+            $message->setMeta('mime_type', $file->getMimeType());
+            $message->setMeta('media_size', (string) $file->getSize());
+        }
 
             return response()->json([
                 'status' => Constants::SUCCESS,

--- a/src/Http/Controllers/MessagingController.php
+++ b/src/Http/Controllers/MessagingController.php
@@ -553,7 +553,7 @@ class MessagingController extends Controller
             'profile_id' => 'required|exists:channels,id',
             'to'         => 'required|string',
             'message'    => 'nullable|string',
-            'media'      => 'nullable|file|mimes:jpeg,png,mp4,3gp,mov|max:102400',
+            'media'      => 'nullable|file|mimes:jpeg,png,mp4,3gp|max:102400',
         ]);
 
         $user = auth()->user();
@@ -608,7 +608,7 @@ class MessagingController extends Controller
 
             if (in_array($mime, ['image/jpeg', 'image/png'])) {
                 $mediaType = 'image';
-            } elseif (in_array($mime, ['video/mp4', 'video/3gpp', 'video/quicktime'])) {
+            } elseif (in_array($mime, ['video/mp4', 'video/3gpp'])) {
                 $mediaType = 'video';
             }
             if (!$mediaType) {

--- a/src/Models/MessageMeta.php
+++ b/src/Models/MessageMeta.php
@@ -9,6 +9,8 @@ class MessageMeta extends Model
 {
     use HasFactory;
 
+    protected $table = 'message_metas';
+
     protected $fillable = [
         'ref_parent',
         'meta_key',
@@ -20,6 +22,6 @@ class MessageMeta extends Model
 
     public function message()
     {
-        return $this->belongsTo(Message::class);
+        return $this->belongsTo(Message::class, 'ref_parent');
     }
 }


### PR DESCRIPTION
## Summary
Add attachment dialog to the chat panel's `+` button to support 
sending image and video files.

## Changes Made

### UI
- Replaced plain `+` button in `chat-panel.blade.php` with attachment 
  wrapper containing a popup dialog
- Dialog shows only **Photos & Videos** option
- File picker restricted to: `image/png`, `image/jpeg`, `video/mp4`, 
  `video/3gpp`
- Removed `required` from text input to allow media-only sends
- Added `enctype="multipart/form-data"` to the send form

### JS
- Added attachment dialog toggle logic in `ui-extras.blade.php`
- Updated form submit in `messaging-actions.blade.php` to use 
  `FormData` instead of `serialize()` to support file uploads

### Backend
- Extended `sendMessage()` in `MessagingController.php`:
  - Updated validation to accept optional `media` file
  - Added media handling — stores file, gets public URL
  - API payload now handles both text and media
  - `Message::create()` saves correct `message_type` and `content`
  - Saves media meta (`media_url`, `media_path`, `mime_type`, `media_size`)

## Files Changed
- `chat-panel.blade.php`
- `ui-extras.blade.php`
- `messaging-actions.blade.php`
- `MessagingController.php`

## Result
Image and video files can now be selected and sent from the chat panel with the preview of the selected image or video.

Closes #60 