### PR TITLE
Fix: Chat auto-scrolls to latest messages on open

### DIFF
--- a/resources/views/messages/partials/chat/scripts/ui-extras.blade.php
+++ b/resources/views/messages/partials/chat/scripts/ui-extras.blade.php
@@ -87,6 +87,7 @@
         let hideTimeout;
         let isUserScrolling = false;
         let isLoadingOlder = false;
+        let shouldStickToBottom = true;
 
         // Keep chat-history logs consistent for scroll-based pagination debugging.
         function logHistoryEvent(level, message, context = {}) {
@@ -257,6 +258,7 @@
         messagesContainer.addEventListener('scroll', function() {
             isUserScrolling = true;
             const isNearBottom = this.scrollHeight - this.scrollTop - this.clientHeight < 100;
+            shouldStickToBottom = isNearBottom;
 
             if (this.scrollTop <= 40) {
                 loadOlderMessages();
@@ -302,6 +304,7 @@
         });
 
         jumpToBottomBtn.querySelector('button').addEventListener('click', function() {
+            shouldStickToBottom = true;
             messagesContainer.scrollTo({
                 top: messagesContainer.scrollHeight,
                 behavior: 'smooth'
@@ -311,17 +314,81 @@
 
         bindStarRatings(messagesContainer);
 
-       function scrollToBottom() {
+        function scrollToBottom() {
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    messagesContainer.scrollTo({
+                        top: messagesContainer.scrollHeight,
+                        behavior: 'auto'
+                    });
+
+                    // One more pass helps when layout settles just after paint.
+                    setTimeout(() => {
+                        if (shouldStickToBottom) {
+                            messagesContainer.scrollTo({
+                                top: messagesContainer.scrollHeight,
+                                behavior: 'auto'
+                            });
+                        }
+                    }, 100);
+                });
+            });
+        }
+
+        function syncScrollToBottom() {
             messagesContainer.scrollTop = messagesContainer.scrollHeight;
         }
 
         scrollToBottom();
 
-        const autoScrollObserver = new ResizeObserver(() => {
-            scrollToBottom();
+        const mutationObserver = new MutationObserver(() => {
+            observeLastMessage();
+
+            if (shouldStickToBottom && !isLoadingOlder) {
+                scrollToBottom();
+            }
         });
 
-        autoScrollObserver.observe(messagesContainer);
+        mutationObserver.observe(messagesContainer, {
+            childList: true,
+            subtree: true,
+        });
+
+        let observedLastMessage = null;
+        const lastMessageResizeObserver = typeof ResizeObserver === 'function'
+            ? new ResizeObserver(() => {
+                if (shouldStickToBottom && !isLoadingOlder) {
+                    scrollToBottom();
+                }
+            })
+            : null;
+
+        function observeLastMessage() {
+            if (!lastMessageResizeObserver) {
+                return;
+            }
+
+            const lastMessage = [...messagesContainer.children]
+                .reverse()
+                .find(el => !el.hasAttribute('data-history-loader'));
+
+            if (observedLastMessage === lastMessage) {
+                return;
+            }
+
+            if (observedLastMessage) {
+                lastMessageResizeObserver.unobserve(observedLastMessage);
+            }
+
+            observedLastMessage = lastMessage || null;
+
+            if (observedLastMessage) {
+                lastMessageResizeObserver.observe(observedLastMessage);
+            }
+        }
+
+        observeLastMessage();
+        syncScrollToBottom();
     } else {
         bindStarRatings(document);
     }

--- a/resources/views/messages/partials/chat/scripts/ui-extras.blade.php
+++ b/resources/views/messages/partials/chat/scripts/ui-extras.blade.php
@@ -312,30 +312,16 @@
         bindStarRatings(messagesContainer);
 
        function scrollToBottom() {
-            requestAnimationFrame(() => {
-                requestAnimationFrame(() => {
-                    messagesContainer.scrollTo({ top: messagesContainer.scrollHeight, behavior: 'auto' });
-                });
-            });
-        }
-
-        function isNearBottom() {
-            return messagesContainer.scrollHeight - messagesContainer.scrollTop - messagesContainer.clientHeight < 100;
+            messagesContainer.scrollTop = messagesContainer.scrollHeight;
         }
 
         scrollToBottom();
 
         const autoScrollObserver = new ResizeObserver(() => {
-            if (isNearBottom()) {
-                scrollToBottom();
-            }
+            scrollToBottom();
         });
 
         autoScrollObserver.observe(messagesContainer);
-
-        setTimeout(() => {
-            autoScrollObserver.disconnect();
-        }, 5000);
     } else {
         bindStarRatings(document);
     }

--- a/resources/views/messages/partials/chat/scripts/ui-extras.blade.php
+++ b/resources/views/messages/partials/chat/scripts/ui-extras.blade.php
@@ -314,49 +314,28 @@
        function scrollToBottom() {
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
-                    messagesContainer.scrollTo({ top: messagesContainer.scrollHeight, behavior: 'instant' });
-                    // extra pass for text-only chats where layout settles slightly later
-                    setTimeout(() => {
-                        messagesContainer.scrollTo({ top: messagesContainer.scrollHeight, behavior: 'instant' });
-                    }, 100);
+                    messagesContainer.scrollTo({ top: messagesContainer.scrollHeight, behavior: 'auto' });
                 });
             });
         }
-        function scrollToBottomAfterMedia() {
-            scrollToBottom();
 
-            const mediaElements = [...messagesContainer.querySelectorAll('img, video')];
-            const pending = mediaElements.filter(el => {
-                if (el.tagName === 'IMG') return !el.complete;
-                if (el.tagName === 'VIDEO') return el.readyState < 1;
-                return false;
-            });
+        function isNearBottom() {
+            return messagesContainer.scrollHeight - messagesContainer.scrollTop - messagesContainer.clientHeight < 100;
+        }
 
-            if (pending.length === 0) return;
+        scrollToBottom();
 
-            let settled = false;
-
-            function onMediaLoaded() {
+        const autoScrollObserver = new ResizeObserver(() => {
+            if (isNearBottom()) {
                 scrollToBottom();
-                const stillPending = [...messagesContainer.querySelectorAll('img, video')].filter(el => {
-                    if (el.tagName === 'IMG') return !el.complete;
-                    if (el.tagName === 'VIDEO') return el.readyState < 1;
-                    return false;
-                });
-                if (stillPending.length === 0) settled = true;
             }
+        });
 
-            pending.forEach(el => {
-                el.addEventListener('load', onMediaLoaded, { once: true });
-                el.addEventListener('loadedmetadata', onMediaLoaded, { once: true });
-                el.addEventListener('error', onMediaLoaded, { once: true });
-            });
+        autoScrollObserver.observe(messagesContainer);
 
-            setTimeout(() => {
-                if (!settled) scrollToBottom();
-            }, 2000);
-        }
-        scrollToBottomAfterMedia();
+        setTimeout(() => {
+            autoScrollObserver.disconnect();
+        }, 5000);
     } else {
         bindStarRatings(document);
     }

--- a/resources/views/messages/partials/chat/scripts/ui-extras.blade.php
+++ b/resources/views/messages/partials/chat/scripts/ui-extras.blade.php
@@ -310,7 +310,53 @@
         });
 
         bindStarRatings(messagesContainer);
-        messagesContainer.scrollTop = messagesContainer.scrollHeight;
+
+       function scrollToBottom() {
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    messagesContainer.scrollTo({ top: messagesContainer.scrollHeight, behavior: 'instant' });
+                    // extra pass for text-only chats where layout settles slightly later
+                    setTimeout(() => {
+                        messagesContainer.scrollTo({ top: messagesContainer.scrollHeight, behavior: 'instant' });
+                    }, 100);
+                });
+            });
+        }
+        function scrollToBottomAfterMedia() {
+            scrollToBottom();
+
+            const mediaElements = [...messagesContainer.querySelectorAll('img, video')];
+            const pending = mediaElements.filter(el => {
+                if (el.tagName === 'IMG') return !el.complete;
+                if (el.tagName === 'VIDEO') return el.readyState < 1;
+                return false;
+            });
+
+            if (pending.length === 0) return;
+
+            let settled = false;
+
+            function onMediaLoaded() {
+                scrollToBottom();
+                const stillPending = [...messagesContainer.querySelectorAll('img, video')].filter(el => {
+                    if (el.tagName === 'IMG') return !el.complete;
+                    if (el.tagName === 'VIDEO') return el.readyState < 1;
+                    return false;
+                });
+                if (stillPending.length === 0) settled = true;
+            }
+
+            pending.forEach(el => {
+                el.addEventListener('load', onMediaLoaded, { once: true });
+                el.addEventListener('loadedmetadata', onMediaLoaded, { once: true });
+                el.addEventListener('error', onMediaLoaded, { once: true });
+            });
+
+            setTimeout(() => {
+                if (!settled) scrollToBottom();
+            }, 2000);
+        }
+        scrollToBottomAfterMedia();
     } else {
         bindStarRatings(document);
     }


### PR DESCRIPTION
When opening a chat, the panel was showing old messages instead of scrolling to the bottom automatically. Users had to manually click "Jump to bottom" every time.

Root cause: The scroll ran once on page load before images/videos finished loading, so scrollHeight was incomplete and the scroll landed in the middle of the chat.

Fix: Instead of scrolling once, the chat now scrolls immediately on open, then re-scrolls each time a media element finishes loading. Added double requestAnimationFrame to wait for layout to settle, a 100ms safety scroll for text-only chats, and a 2s fallback for slow/broken media.

File changed: ui-extras.blade.php

Closes #63 