### PR TITLE
fix: analytics chart image dropped in outbound pipeline

### DIFF
--- a/src/Jobs/MessageJobs/ProcessChatbotResponseJob.php
+++ b/src/Jobs/MessageJobs/ProcessChatbotResponseJob.php
@@ -92,6 +92,7 @@ class ProcessChatbotResponseJob extends BaseJob
         return match ($messageType) {
             'product' => $this->handleProduct($message),
             'text' => $this->handleText($message),
+            'image' => $this->handleImage($message),
             default => $this->handleUnknown($message),
         };
     }
@@ -201,6 +202,60 @@ class ProcessChatbotResponseJob extends BaseJob
         ]));
 
         return null;
+    }
+
+    private function handleImage(array $message): ?SendWhatsAppReplyJob
+    {
+        $content = $message['content'] ?? [];
+        if (empty($content)) {
+            $this->logWarning('Image message has empty content' . $this->ctx([
+                'inbound_message_id' => $this->inboundMessage->id,
+            ]));
+            return null;
+        }
+
+        $base64 = $content['base64'] ?? null;
+        if (!$base64) {
+            $this->logWarning('Image message has no base64 content' . $this->ctx([
+                'inbound_message_id' => $this->inboundMessage->id,
+            ]));
+            return null;
+        }
+
+        $mimeType = $content['mime_type'] ?? 'image/png';
+        $mediaService = new MediaStorageService($this->inboundMessage->channel);
+        $storedMedia = $mediaService->storeBase64Content(
+            $base64,
+            'image',
+            $mimeType,
+            [
+                'filename' => 'analytics_chart',
+            ]
+        );
+
+        if (!$storedMedia) {
+            $this->logWarning('Failed to persist analytics chart image from image message' . $this->ctx([
+                'inbound_message_id' => $this->inboundMessage->id,
+            ]));
+            return null;
+        }
+
+        $this->logInfo('Analytics chart image persisted and will be sent as WhatsApp media' . $this->ctx([
+            'inbound_message_id' => $this->inboundMessage->id,
+            'mime_type' => $mimeType,
+            'stored_url' => $storedMedia['url'] ?? null,
+        ]));
+
+        return new SendWhatsAppReplyJob(
+            $this->inboundMessage,
+            [
+                'type' => 'image',
+                'caption' => 'Analytics chart',
+                'image_url' => $storedMedia['url'],
+                'stored_media' => $storedMedia,
+                'integration_id' => $this->integrationId,
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
## Problem

The analytics chart image generated by chatbot-core is dropped in the smart-messenger outbound pipeline. `routeMessage()` only handled `text` and `product` types — the `image` type fell to `handleUnknown()` and was silently discarded.

## Root cause

chatbot-core now attaches the chart as `{"type": "image", "content": {"base64": "...", "mime_type": "image/png"}}` in `messages[]`. But `ProcessChatbotResponseJob::routeMessage()` had no handler for the `image` type.

The existing `extractToolPayloadReplyJobs()` method handled base64 charts from `tool_payloads`, but that path only works on `/api/chat/v2`. The deployment uses `/api/chat/v3` which doesn't pass `tool_payloads` through the event sink.

## Fix

1. Added `'image' => $this->handleImage($message)` to the `routeMessage()` match statement
2. Added `handleImage()` method that reads `content.base64` from the image message, persists it via `MediaStorageService::storeBase64Content()`, and dispatches `SendWhatsAppReplyJob` with `type: 'image'`

This fix is API-version-agnostic — works on v1, v2, and v3 since all three pass `messages[]` through `ProcessChatbotResponseJob`.

Closes #68
