### PR TITLE
feat: add FAQ CRUD UI and API endpoint (IQU-77)

### DIFF
--- a/database/migrations/2025_06_12_000001_create_faq_items_table.php
+++ b/database/migrations/2025_06_12_000001_create_faq_items_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('faq_items', function (Blueprint $table) {
+            $table->id();
+            $table->ulid('uid')->unique();
+            $table->unsignedBigInteger('integration_id');
+            $table->text('question');
+            $table->text('answer');
+            $table->string('status')->default('active');
+            $table->integer('sort_order')->default(0);
+            $table->bigInteger('created_by')->default(0);
+            $table->bigInteger('updated_by')->default(0);
+            $table->timestamps();
+
+            $table->index(['integration_id', 'status'], 'faq_items_integration_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('faq_items');
+    }
+};

--- a/database/seeders/SmartMessengerSeeder.php
+++ b/database/seeders/SmartMessengerSeeder.php
@@ -29,6 +29,12 @@ class SmartMessengerSeeder extends BaseSeeder
                 'icon'  => 'fas fa-tower-broadcast',
                 'label' => 'Channels',
                 'route' => 'channels.index',
+
+            ],
+            [
+                'icon'  => 'fas fa-question-circle',
+                'label' => 'FAQ',
+                'route' => 'faq.index',
             ],
         ],
     ];

--- a/resources/views/faq/form.blade.php
+++ b/resources/views/faq/form.blade.php
@@ -1,0 +1,84 @@
+@extends('userinterface::layouts.app')
+
+@section('page-title', isset($faq) ? 'Edit FAQ Item' : 'Create FAQ Item')
+
+@section('content')
+<div class="" style="max-width: 700px;">
+
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h5 class="fs-6 text-muted mb-0">
+            {{ isset($faq) ? 'Edit FAQ Item' : 'Create FAQ Item' }}
+        </h5>
+        <a href="{{ route('faq.index') }}" class="btn btn-sm btn-outline-secondary">
+            <i class="fas fa-fw fa-arrow-left"></i>
+            <span class="ms-1">Back</span>
+        </a>
+    </div>
+
+    @if($errors->any())
+        <div class="alert alert-danger">
+            <ul class="mb-0">
+                @foreach($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    <form method="POST"
+          action="{{ isset($faq) ? route('faq.update', $faq) : route('faq.store') }}">
+        @csrf
+        @if(isset($faq)) @method('PUT') @endif
+
+        <div class="mb-3">
+            <label class="form-label">Integration <span class="text-danger">*</span></label>
+            <select name="integration_id" class="form-select" required>
+                <option value="">— Select Integration —</option>
+                @foreach($integrations as $integration)
+                    <option value="{{ $integration->id }}"
+                        @selected(old('integration_id', $faq->integration_id ?? '') == $integration->id)>
+                        {{ $integration->name }}
+                    </option>
+                @endforeach
+            </select>
+        </div>
+
+        <div class="mb-3">
+            <label class="form-label">Question <span class="text-danger">*</span></label>
+            <textarea name="question" class="form-control" rows="3" required
+                      placeholder="e.g. What are your delivery timings?">{{ old('question', $faq->question ?? '') }}</textarea>
+        </div>
+
+        <div class="mb-3">
+            <label class="form-label">Answer <span class="text-danger">*</span></label>
+            <textarea name="answer" class="form-control" rows="5" required
+                      placeholder="e.g. We deliver between 9am and 6pm Monday to Friday.">{{ old('answer', $faq->answer ?? '') }}</textarea>
+        </div>
+
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                <label class="form-label">Status</label>
+                <select name="status" class="form-select">
+                    <option value="active"
+                        @selected(old('status', $faq->status ?? 'active') === 'active')>Active</option>
+                    <option value="inactive"
+                        @selected(old('status', $faq->status ?? '') === 'inactive')>Inactive</option>
+                </select>
+            </div>
+            <div class="col-md-6 mb-3">
+                <label class="form-label">Sort Order</label>
+                <input type="number" name="sort_order" class="form-control" min="0"
+                       value="{{ old('sort_order', $faq->sort_order ?? 0) }}">
+            </div>
+        </div>
+
+        <div class="d-flex gap-2">
+            <button type="submit" class="btn btn-primary">
+                <i class="fas fa-fw fa-save"></i>
+                {{ isset($faq) ? 'Update' : 'Create' }}
+            </button>
+            <a href="{{ route('faq.index') }}" class="btn btn-outline-secondary">Cancel</a>
+        </div>
+    </form>
+</div>
+@endsection

--- a/resources/views/faq/index.blade.php
+++ b/resources/views/faq/index.blade.php
@@ -1,0 +1,100 @@
+@extends('userinterface::layouts.app')
+
+@section('page-title', 'FAQ Items')
+@section('meta-description', 'Manage FAQ items per integration')
+
+@section('content')
+<div class="">
+    {{-- Header --}}
+    <div class="d-flex justify-content-between align-items-center mb-2">
+        <h5 class="fs-6 text-muted">
+            Total {{ $faqs->total() }} FAQ Item(s)
+        </h5>
+        <a href="{{ route('faq.create') }}" class="btn btn-sm btn-outline-primary">
+            <i class="fa-regular fa-fw fa-plus"></i>
+            <span class="d-none d-md-inline-block ms-1">FAQ Item</span>
+        </a>
+    </div>
+
+    {{-- Success message --}}
+    @if(session('success'))
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            {{ session('success') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
+    @endif
+
+    {{-- Filters --}}
+    <form method="GET" class="d-flex gap-2 mb-3 flex-wrap">
+        <select name="integration_id" class="form-select form-select-sm" style="width:auto;">
+            <option value="">All Integrations</option>
+            @foreach($integrations as $integration)
+                <option value="{{ $integration->id }}" @selected(request('integration_id') == $integration->id)>
+                    {{ $integration->name }}
+                </option>
+            @endforeach
+        </select>
+        <input type="text" name="search" class="form-control form-control-sm" style="width:auto;"
+               placeholder="Search question or answer..." value="{{ request('search') }}">
+        <button class="btn btn-sm btn-outline-secondary">Filter</button>
+        @if(request('integration_id') || request('search'))
+            <a href="{{ route('faq.index') }}" class="btn btn-sm btn-outline-danger">Clear</a>
+        @endif
+    </form>
+
+    {{-- Table --}}
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Integration</th>
+                    <th>Question</th>
+                    <th>Answer</th>
+                    <th>Status</th>
+                    <th>Sort</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($faqs as $faq)
+                <tr>
+                    <td>{{ $faq->id }}</td>
+                    <td>{{ optional($faq->integration)->name ?? '—' }}</td>
+                    <td>{{ Str::limit($faq->question, 80) }}</td>
+                    <td>{{ Str::limit($faq->answer, 80) }}</td>
+                    <td>
+                        <span class="badge bg-{{ $faq->status === 'active' ? 'success' : 'secondary' }}">
+                            {{ ucfirst($faq->status) }}
+                        </span>
+                    </td>
+                    <td>{{ $faq->sort_order }}</td>
+                    <td>
+                        <div class="d-flex align-items-center justify-content-center gap-2">
+                            <a href="{{ route('faq.edit', $faq) }}" class="btn btn-sm btn-outline-dark">
+                                <i class="fas fa-fw fa-edit"></i>
+                            </a>
+                            <form action="{{ route('faq.destroy', $faq) }}" method="POST"
+                                  onsubmit="return confirm('Delete this FAQ item?')">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-sm btn-outline-danger">
+                                    <i class="fas fa-fw fa-trash"></i>
+                                </button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+                @empty
+                <tr>
+                    <td colspan="7" class="text-center text-muted">No FAQ items found.</td>
+                </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    {{-- Pagination --}}
+    {{ $faqs->links() }}
+</div>
+@endsection

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,8 @@ use Illuminate\Support\Facades\Route;
 use Iquesters\SmartMessenger\Http\Controllers\Api\ContactController;
 use Iquesters\SmartMessenger\Http\Controllers\Api\DiagnosticsController;
 use Iquesters\SmartMessenger\Http\Controllers\Api\ChatSessionHandoverController;
+use Iquesters\SmartMessenger\Http\Controllers\Api\FaqApiController;
+
 
 // All middleware and prefix are handled in the service provider
 Route::get('/contacts', [ContactController::class, 'index']);
@@ -14,3 +16,5 @@ Route::post('/chat-sessions/handover/activate', [ChatSessionHandoverController::
     ->name('smart-messenger.chat-sessions.handover.activate');
 Route::post('/chat-sessions/handover/return-to-bot', [ChatSessionHandoverController::class, 'returnToBot'])
     ->name('smart-messenger.chat-sessions.handover.return-to-bot');
+// FAQ API — consumed by chatbot-job
+Route::get('/faq/{integrationUid}', [FaqApiController::class, 'index']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,6 +50,19 @@ Route::middleware(['web', 'auth'])->group(function () {
     //     ->group(function () {
     //         Route::get('/', 'index')->name('index');
     //     });
+
+    // FAQ Routes
+    Route::controller(\Iquesters\SmartMessenger\Http\Controllers\FaqController::class)
+        ->prefix('faq')
+        ->name('faq.')
+        ->group(function () {
+            Route::get('/', 'index')->name('index');
+            Route::get('/create', 'create')->name('create');
+            Route::post('/', 'store')->name('store');
+            Route::get('/{faq}/edit', 'edit')->name('edit');
+            Route::put('/{faq}', 'update')->name('update');
+            Route::delete('/{faq}', 'destroy')->name('destroy');
+        });
 });
 
 // Webhook routes (typically without auth middleware)

--- a/src/Http/Controllers/Api/FaqApiController.php
+++ b/src/Http/Controllers/Api/FaqApiController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Iquesters\SmartMessenger\Http\Controllers\Api;
+
+use Illuminate\Routing\Controller;
+use Iquesters\SmartMessenger\Models\FaqItem;
+use Iquesters\Integration\Models\Integration;
+
+class FaqApiController extends Controller
+{
+    /**
+     * GET /api/faq/{integrationUid}
+     * Returns active FAQ items for a given integration.
+     * Consumed by chatbot-job FAQ upsert pipeline.
+     */
+    public function index(string $integrationUid)
+    {
+        $integration = Integration::where('uid', $integrationUid)->firstOrFail();
+
+        $faqs = FaqItem::where('integration_id', $integration->id)
+            ->active()
+            ->orderBy('sort_order')
+            ->get(['id', 'question', 'answer']);
+
+        return response()->json($faqs);
+    }
+}

--- a/src/Http/Controllers/FaqController.php
+++ b/src/Http/Controllers/FaqController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Iquesters\SmartMessenger\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Iquesters\SmartMessenger\Models\FaqItem;
+use Iquesters\Integration\Models\Integration;
+
+class FaqController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = FaqItem::with('integration')->orderBy('sort_order');
+
+        if ($request->filled('integration_id')) {
+            $query->where('integration_id', $request->integration_id);
+        }
+
+        if ($request->filled('search')) {
+            $search = $request->search;
+            $query->where(function ($q) use ($search) {
+                $q->where('question', 'like', "%{$search}%")
+                  ->orWhere('answer', 'like', "%{$search}%");
+            });
+        }
+
+        $faqs = $query->paginate(25)->withQueryString();
+        $integrations = Integration::orderBy('name')->get();
+
+        return view('smartmessenger::faq.index', compact('faqs', 'integrations'));
+    }
+
+    public function create()
+    {
+        $integrations = Integration::orderBy('name')->get();
+        return view('smartmessenger::faq.form', compact('integrations'));
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'integration_id' => 'required|integer',
+            'question'       => 'required|string',
+            'answer'         => 'required|string',
+            'status'         => 'in:active,inactive',
+            'sort_order'     => 'integer|min:0',
+        ]);
+
+        FaqItem::create($validated);
+
+        return redirect()->route('faq.index')->with('success', 'FAQ item created successfully.');
+    }
+
+    public function edit(FaqItem $faq)
+    {
+        $integrations = Integration::orderBy('name')->get();
+        return view('smartmessenger::faq.form', compact('faq', 'integrations'));
+    }
+
+    public function update(Request $request, FaqItem $faq)
+    {
+        $validated = $request->validate([
+            'integration_id' => 'required|integer',
+            'question'       => 'required|string',
+            'answer'         => 'required|string',
+            'status'         => 'in:active,inactive',
+            'sort_order'     => 'integer|min:0',
+        ]);
+
+        $faq->update($validated);
+
+        return redirect()->route('faq.index')->with('success', 'FAQ item updated successfully.');
+    }
+
+    public function destroy(FaqItem $faq)
+    {
+        $faq->delete();
+        return redirect()->route('faq.index')->with('success', 'FAQ item deleted.');
+    }
+}

--- a/src/Models/FaqItem.php
+++ b/src/Models/FaqItem.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Iquesters\SmartMessenger\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Iquesters\Integration\Models\Integration;
+
+class FaqItem extends Model
+{
+    use HasFactory;
+
+    protected $table = 'faq_items';
+
+    protected $fillable = [
+        'uid',
+        'integration_id',
+        'question',
+        'answer',
+        'status',
+        'sort_order',
+        'created_by',
+        'updated_by',
+    ];
+
+    /*
+    |--------------------------------------------------------------------------
+    | Relationships
+    |--------------------------------------------------------------------------
+    */
+
+    public function integration()
+    {
+        return $this->belongsTo(Integration::class, 'integration_id');
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Scopes
+    |--------------------------------------------------------------------------
+    */
+
+    public function scopeActive($query)
+    {
+        return $query->where('status', 'active');
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boot
+    |--------------------------------------------------------------------------
+    */
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (empty($model->uid)) {
+                $model->uid = \Illuminate\Support\Str::ulid();
+            }
+            if (auth()->check()) {
+                $model->created_by = auth()->id();
+                $model->updated_by = auth()->id();
+            }
+        });
+
+        static::updating(function ($model) {
+            if (auth()->check()) {
+                $model->updated_by = auth()->id();
+            }
+        });
+    }
+}


### PR DESCRIPTION
 What this PR does
Adds a proper FAQ management system to smart-messenger, replacing the fragile Google Docs source with a database-backed CRUD UI.

## Changes

**Database**
- New migration: `faq_items` table with `integration_id`, `question`, `answer`, `status`, `sort_order`

**Backend**
- `FaqItem` model with `active()` scope and `belongsTo` Integration relationship
- `FaqController` — full CRUD (index, create, store, edit, update, destroy)
- `FaqApiController` — `GET /api/smart-messenger/faq/{integrationUid}` returns active FAQ items for a given integration (consumed by chatbot-job)

**Routes**
- Web routes added under `/faq` prefix
- API route added to `api.php`

**Views**
- `faq/index.blade.php` — table with search/filter by integration, status badge, pagination
- `faq/form.blade.php` — create/edit form

**Navigation**
- FAQ link added to smart-messenger sidebar via seeder

## How to test
1. Run `php artisan migrate`
2. Run `php artisan smart-messenger:seed`
3. Go to `/faq` — FAQ page should appear in sidebar
4. Create a FAQ item — should save to `faq_items` table
5. Hit `GET /api/smart-messenger/faq/{integrationUid}` — should return active FAQ items as JSON

## Depends on
- chatbot-job #33 — will consume the API endpoint to build FAQ vectors