### PR TITLE
fix: restrict FAQ access to organisation-based only

### DIFF
--- a/src/Http/Controllers/FaqController.php
+++ b/src/Http/Controllers/FaqController.php
@@ -128,15 +128,13 @@ class FaqController extends Controller
             $organisationIds = $user->organisations()->pluck('organisations.id');
         }
 
-        return Integration::query()
-            ->where(function ($query) use ($user, $organisationIds) {
-                $query->where('user_id', $user->id);
+        if ($organisationIds->isEmpty() || ! method_exists(Integration::class, 'organisations')) {
+            return collect();
+        }
 
-                if ($organisationIds->isNotEmpty() && method_exists(Integration::class, 'organisations')) {
-                    $query->orWhereHas('organisations', function ($q) use ($organisationIds) {
-                        $q->whereIn('organisations.id', $organisationIds);
-                    });
-                }
+        return Integration::query()
+            ->whereHas('organisations', function ($q) use ($organisationIds) {
+                $q->whereIn('organisations.id', $organisationIds);
             })
             ->orderBy('name')
             ->get();


### PR DESCRIPTION
Changes FAQ access control from user_id-based to pure organisation-based, matching how the message viewer resolves accessible integrations. A user who is not related to an organisation via channel membership will no longer see or manage its FAQ items.