### PR TITLE
feat: add PDF file transfer support in chat inbox

### DIFF
--- a/resources/views/messages/partials/chat/chat-panel.blade.php
+++ b/resources/views/messages/partials/chat/chat-panel.blade.php
@@ -132,6 +132,9 @@
             <div id="mediaPreview" class="d-none px-3 py-2 border-top bg-light d-flex align-items-center gap-2">
                 <img id="mediaPreviewImg" src="" alt="preview" style="max-height:80px; max-width:80px; object-fit:cover; border-radius:8px;" class="d-none">
                 <video id="mediaPreviewVideo" src="" style="max-height:80px; max-width:80px; border-radius:8px;" controls class="d-none"></video>
+                <div id="mediaPreviewPdf" class="d-none align-items-center gap-2">
+                    <i class="fas fa-file-pdf text-danger" style="font-size:2rem;"></i>
+                </div>
                 <div class="flex-grow-1">
                     <div id="mediaPreviewName" class="small text-muted"></div>
                     <div id="mediaSizeWarning" class="small text-warning d-none">Video exceeds WhatsApp 16 MB limit &mdash; it will be compressed</div>
@@ -162,7 +165,7 @@
                     <input type="file"
                         id="mediaFileInput"
                         name="media"
-                        accept="image/png,image/jpeg,video/mp4,video/3gpp"
+                        accept="image/png,image/jpeg,video/mp4,video/3gpp,application/pdf"
                         class="d-none">
 
                     <button type="button"
@@ -182,6 +185,15 @@
                                 <i class="fas fa-image text-primary" style="font-size:14px;"></i>
                             </span>
                             <span class="fw-medium">Photos &amp; Videos</span>
+                        </button>
+                         <button type="button"
+                                id="attachPDF"
+                                class="btn btn-sm w-100 text-start px-3 py-2 d-flex align-items-center gap-2 rounded-0 border-0 bg-transparent">
+                            <span class="rounded-circle d-flex align-items-center justify-content-center"
+                                style="width:32px;height:32px;background:#ffe0e0;">
+                                <i class="fas fa-file-pdf text-danger" style="font-size:14px;"></i>
+                            </span>
+                            <span class="fw-medium">PDF Document</span>
                         </button>
                     </div>
                 </div>

--- a/resources/views/messages/partials/chat/messages-list.blade.php
+++ b/resources/views/messages/partials/chat/messages-list.blade.php
@@ -106,12 +106,26 @@
                             <audio controls class="w-100 mb-1">
                                 <source src="{{ $mediaUrl }}">
                             </audio>
+                       @elseif ($msg->message_type === 'document')
+                            <a href="{{ $mediaUrl }}" target="_blank" class="d-flex align-items-center gap-2 text-decoration-none p-2" style="min-width:200px; max-width:280px;">
+                                <div class="d-flex align-items-center justify-content-center rounded flex-shrink-0"
+                                    style="width:40px;height:40px;background:#ffe0e0;">
+                                    <i class="fas fa-file-pdf text-danger" style="font-size:20px;"></i>
+                                </div>
+                                <div class="overflow-hidden flex-grow-1">
+                                    <div class="fw-medium text-dark text-truncate" style="font-size:13px;">
+                                        {{ $msg->getMeta('original_filename') ?? basename($mediaUrl) }}
+                                    </div>
+                                    <div class="text-muted" style="font-size:11px;">PDF Document</div>
+                                </div>
+                                <i class="fas fa-download text-muted ms-auto flex-shrink-0"></i>
+                            </a>
                         @else
                             <a href="{{ $mediaUrl }}" target="_blank" class="d-block text-decoration-none">
                                 Download file
                             </a>
-                        @endif
-                    @endif
+                         @endif
+                     @endif
 
                     @if ($caption)
                         <div class="media-caption px-2 py-1 small">

--- a/resources/views/messages/partials/chat/scripts/ui-extras.blade.php
+++ b/resources/views/messages/partials/chat/scripts/ui-extras.blade.php
@@ -417,6 +417,14 @@
             fileInput.click();
         });
 
+        const attachPdfBtn = document.getElementById('attachPDF');
+        if (attachPdfBtn) {
+            attachPdfBtn.addEventListener('click', function () {
+                dialog.classList.add('d-none');
+                fileInput.click();
+            });
+        }
+
         fileInput.addEventListener('change', function () {
             const file = fileInput.files[0];
             if (!file) return;
@@ -424,31 +432,43 @@
             const preview = document.getElementById('mediaPreview');
             const previewImg = document.getElementById('mediaPreviewImg');
             const previewVideo = document.getElementById('mediaPreviewVideo');
+            const previewPdf = document.getElementById('mediaPreviewPdf');
             const previewName = document.getElementById('mediaPreviewName');
             const sizeWarning = document.getElementById('mediaSizeWarning');
 
             preview.classList.remove('d-none');
             previewName.textContent = file.name;
 
-            if (file.type.startsWith('video/') && file.size > 16 * 1024 * 1024) {
-                sizeWarning.classList.remove('d-none');
-            } else {
-                sizeWarning.classList.add('d-none');
-            }
+            // Hide all previews first
+            previewImg.classList.add('d-none');
+            previewVideo.classList.add('d-none');
+            previewPdf?.classList.add('d-none');
+            sizeWarning.classList.add('d-none');
 
-            const reader = new FileReader();
-            reader.onload = function(e) {
-                if (file.type.startsWith('image/')) {
+            if (file.type === 'application/pdf') {
+                previewPdf?.classList.remove('d-none');
+                if (file.size > 100 * 1024 * 1024) {
+                    sizeWarning.textContent = 'PDF exceeds WhatsApp 100 MB limit';
+                    sizeWarning.classList.remove('d-none');
+                }
+            } else if (file.type.startsWith('image/')) {
+                const reader = new FileReader();
+                reader.onload = function(e) {
                     previewImg.src = e.target.result;
                     previewImg.classList.remove('d-none');
-                    previewVideo.classList.add('d-none');
-                } else {
+                };
+                reader.readAsDataURL(file);
+            } else if (file.type.startsWith('video/')) {
+                if (file.size > 16 * 1024 * 1024) {
+                    sizeWarning.classList.remove('d-none');
+                }
+                const reader = new FileReader();
+                reader.onload = function(e) {
                     previewVideo.src = e.target.result;
                     previewVideo.classList.remove('d-none');
-                    previewImg.classList.add('d-none');
-                }
-            };
-            reader.readAsDataURL(file);
+                };
+                reader.readAsDataURL(file);
+            }
         });
 
         document.getElementById('removeMedia')?.addEventListener('click', function() {
@@ -457,6 +477,7 @@
             document.getElementById('mediaPreviewImg').src = '';
             document.getElementById('mediaPreviewVideo').src = '';
             document.getElementById('mediaSizeWarning')?.classList.add('d-none');
+            document.getElementById('mediaPreviewPdf')?.classList.add('d-none');
         });
     })();
 </script>

--- a/src/Http/Controllers/MessagingController.php
+++ b/src/Http/Controllers/MessagingController.php
@@ -84,7 +84,7 @@ class MessagingController extends Controller
             'profile_id' => 'required|exists:channels,id',
             'to' => 'required|string',
             'message' => 'nullable|string',
-            'media' => 'nullable|file|mimes:jpeg,png,mp4,3gp|max:102400',
+            'media' => 'nullable|file|mimes:jpeg,png,mp4,3gp,pdf|max:102400',
         ]);
 
         $user = auth()->user();

--- a/src/Services/MessagingSendService.php
+++ b/src/Services/MessagingSendService.php
@@ -320,6 +320,7 @@ class MessagingSendService
 
             if ($hasMedia) {
                 $message->setMeta('whatsapp_media_id', (string) $whatsAppMediaId);
+                $message->setMeta('original_filename', $media->getClientOriginalName());
                 $this->storeMediaMeta($message, $storedPath, $mediaUrl, $mimeType, $media->getSize());
             }
 
@@ -393,6 +394,10 @@ class MessagingSendService
             return 'video';
         }
 
+        if ($mimeType === 'application/pdf') {
+            return 'document';
+        }
+
         return null;
     }
 
@@ -463,8 +468,9 @@ class MessagingSendService
         }
 
         $limits = [
-            'image' => 16 * 1024 * 1024,
-            'video' => 64 * 1024 * 1024,
+            'image'    => 16 * 1024 * 1024,
+            'video'    => 64 * 1024 * 1024,
+            'document' => 100 * 1024 * 1024,
         ];
 
         $type = $this->resolveSupportedMediaType($mimeType);


### PR DESCRIPTION
Added support for sending PDF documents via WhatsApp from the chat inbox. Users can now select PDF files through the attachment dialog alongside the existing Photos & Videos option.
Changes:

Added "PDF Document" option in the attachment dialog
Added PDF preview showing PDF icon and filename before sending
Added PDF size warning when file exceeds WhatsApp's 100MB limit
Added document as a supported media type in MessagingSendService.php
Added PDF mime type validation in MessagingController.php
Added original filename storage in message meta for display
Added professional PDF bubble display in chat with icon, filename and download button

Files Changed:

chat-panel.blade.php
ui-extras.blade.php
messages-list.blade.php
MessagingSendService.php
MessagingController.php

Tested:

PDF option visible in attachment dialog
PDF preview shows icon and filename before sending
PDF sends successfully via WhatsApp
PDF displays with icon and original filename in chat
Size warning shows for files over 100MB